### PR TITLE
compensate for multiple dex files for single jars

### DIFF
--- a/sbt-plugin/src/main/scala/plugin.scala
+++ b/sbt-plugin/src/main/scala/plugin.scala
@@ -683,9 +683,14 @@ object Keys {
     val dx = ((dex in Android).value * "*.dex" get) map { f =>
       (f, s"protify-dex/${f.getName}")
     }
+    val enumRe = """classes(\d+).dex""".r
     val pd = (predex in Android).value.flatMap(_._2 * "*.dex" get) map { f =>
       val name = f.getParentFile.getName.dropRight(4) // ".jar"
-      (f, s"protify-dex/$name.dex")
+      val ext = f.getName match {
+        case enumRe(num) ⇒ s"_$num"
+        case _ ⇒ ""
+      }
+      (f, s"protify-dex/$name$ext.dex")
     }
 
     val prefixlen = "protify-dex/".length


### PR DESCRIPTION
When creating the dex jar, the jar name (directory) is extracted from
the path of a predexed dependency, although a jar can contain multiple
dexes, which will be mapped to the same jar and cause a duplicate entry
error.
